### PR TITLE
fix: conflit with uno softwareserial headers

### DIFF
--- a/humanstaticLite.cpp
+++ b/humanstaticLite.cpp
@@ -197,13 +197,13 @@ void HumanStaticLite::data_printf(const unsigned char* buff, int len){
 }
 
 float HumanStaticLite::decodeVal_func(int val, bool decode){
-  if(!decode) return val*unit;   //Calculate distance
+  if(!decode) return (val * SEEED_HUMAN_UNIT);   //Calculate distance
   else{                          //Calculate speed
     if(val == 0x0A){
       return 0;
     }
-    else if(val > 0x0A) return -((val-10)*unit);   //Away speed is negative
-    else if(val < 0x0A) return (val)*unit;         //Approach speed is positive
+    else if(val > 0x0A) return -((val-10) * SEEED_HUMAN_UNIT);   //Away speed is negative
+    else if(val < 0x0A) return (val) * SEEED_HUMAN_UNIT;         //Approach speed is positive
   }
   return 0;
 }

--- a/humanstaticLite.h
+++ b/humanstaticLite.h
@@ -42,7 +42,7 @@
 
 #define reset_frame_len 10       //Reset data frame length
 
-#define unit          0.5        //Calculate unit steps
+#define SEEED_HUMAN_UNIT 0.5     //Calculate unit steps
 
 //Reset data frame
 const unsigned char reset_frame[10] = {0x53, 0x59, 0x01, 0x02, 0x00, 0x01, 0x0F, 0xBF, 0x54, 0x43};


### PR DESCRIPTION
Using Uno family to use this library could cause the `unit` to be in conflict.
Change the name of `unit` to be more specific to this library.